### PR TITLE
Fix missing UFFDIO_WRITEPROTECT ioctl for write protecting

### DIFF
--- a/src/copy_interpose.c
+++ b/src/copy_interpose.c
@@ -353,6 +353,18 @@ void *memcpy(void *dest, const void *src, size_t n) {
         perror("register with WP");
         abort();
       }
+      struct uffdio_writeprotect wp;
+      wp.range.start = (uint64_t)(src_entry->addr + src_entry->offset);
+      wp.range.len = (uint64_t)src_entry->len;
+      wp.mode = UFFDIO_WRITEPROTECT_MODE_WP;
+      if (ioctl(uffd, UFFDIO_WRITEPROTECT, &wp) == -1) {
+        if (errno == EINVAL) {
+          LOG("[%s] write-protection fault by userfaultfd may not be"
+              "supported by the current kernel\n");
+        }
+        perror("Writeprotect pages");
+        abort();
+      }
     }
 
     size_t left_fringe_len = LEFT_FRINGE_LEN(dest);


### PR DESCRIPTION
As per documentation of userfaultfd (https://man7.org/linux/man-pages/man2/userfaultfd.2.html):

       After the UFFDIO_REGISTER ioctl completed with
       UFFDIO_REGISTER_MODE_WP mode set, the user can write-protect any
       existing memory within the range using the ioctl
       UFFDIO_WRITEPROTECT where uffdio_writeprotect.mode should be set
       to UFFDIO_WRITEPROTECT_MODE_WP.

zIO is currently missing the UFFDIO_WRITEPROTECT call after registering source buffers, causing writes to source buffers not to fault. By adding this call, the writes correctly generate faults.